### PR TITLE
Add GitHub token to labeler workflow for improved security

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -17,3 +17,4 @@ jobs:
         uses: crazy-max/ghaction-github-labeler@v4.1.0
         with:
           skip-delete: true
+          github-token: ${{ secrets.GIT_TOKEN }}


### PR DESCRIPTION
Add GitHub token to labeler workflow for improved security