### PR TITLE
Update the reference documentation to use the correct module name 'py…

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -3,6 +3,6 @@
 ## pydatautils
 
 ```{eval-rst}
-.. automodule:: pydatautils
+.. automodule:: pydataassist
    :members:
 ```


### PR DESCRIPTION
…dataassist'.