### PR TITLE
Add htmlzip format to the build process in .readthedocs.yml

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,7 +5,8 @@ build:
     python: "3.10"
 sphinx:
   configuration: docs/conf.py
-formats: all
+formats:
+  - htmlzip
 python:
   install:
     - requirements: docs/requirements.txt


### PR DESCRIPTION
Add htmlzip format to the build process in .readthedocs.yml